### PR TITLE
Generate .aar file instead of .apklib.

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -12,7 +12,7 @@
 
     <name>Seamless Android</name>
     <artifactId>seamless-android</artifactId>
-    <packaging>apklib</packaging>
+    <packaging>aar</packaging>
 
     <build>
         <plugins>
@@ -26,7 +26,7 @@
             </plugin>
 
             <plugin>
-                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <groupId>com.simpligility.maven.plugins</groupId>
                 <artifactId>android-maven-plugin</artifactId>
                 <version>${android.maven.plugin.version}</version>
                 <extensions>true</extensions>
@@ -104,8 +104,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.android.support</groupId>
-            <artifactId>support-v13</artifactId>
+            <groupId>android.support</groupId>
+            <artifactId>compatibility-v13</artifactId>
             <version>${android.support.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
         <weld.version>1.1.10.Final</weld.version>
         <kxml.version>2.3.0</kxml.version>
         <android.version>4.0.1.2</android.version>
-        <android.support.version>18.0.0</android.support.version>
-        <android.maven.plugin.version>3.8.2</android.maven.plugin.version>
+        <android.support.version>21.0.1</android.support.version>
+        <android.maven.plugin.version>4.0.0-rc.3</android.maven.plugin.version>
 
     </properties>
 


### PR DESCRIPTION
Switched to the native .AAR format, as outlined in:
https://code.google.com/p/maven-android-plugin/wiki/ApkLib
-> android-maven-plugin can also consume .aar properly now, so  it's not a breaking change.

Further upped the compatibility-v13 library version to 21.0.1. 
It requires the user to compile the compatibility library using https://github.com/mosabua/maven-android-sdk-deployer first.

Note: Once google increases the compatibility-v13 version, new developers of this library most likely are required to update this projects reference to that version.
